### PR TITLE
Compile and run the configure script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,12 @@ distclean: clean
 
 -include config.mk
 
-config.mk:
-	@echo
-	@echo "Please run configure before building"
-	@echo
-	@exit 1
+config.mk: configure
+	./configure
+
+configure: configure.ml
+	ocamlfind ocamlc -linkpkg -package findlib,cmdliner -o configure configure.ml
+	@rm -f configure.cm*
 
 setup.bin: setup.ml
 	@ocamlopt.opt -o $@ $< || ocamlopt -o $@ $< || ocamlc -o $@ $<

--- a/configure.ml
+++ b/configure.ml
@@ -1,7 +1,3 @@
-#!/usr/bin/env ocaml
-
-#use "topfind"
-#require "cmdliner"
 
 let config_mk = "config.mk"
 


### PR DESCRIPTION
Using toplevel directives ('#require "cmdliner"' doesn't seem to
work reliably)

Signed-off-by: David Scott dave.scott@eu.citrix.com
