### PR TITLE
Use mtime rather than Unix/Oclock

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -57,7 +57,7 @@ Library message_switch_server
   Findlibparent:      message_switch
   Findlibname:        server
   Modules:            Clock, Relation, Q, Logging, Switch
-  BuildDepends:       lwt,lwt.syntax,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch, bisect
+  BuildDepends:       lwt,lwt.syntax,mtime,mtime.os,cohttp (>= 0.15.0),cohttp.lwt,rpclib,rpclib.json,rpclib.syntax,message_switch, bisect
 
 Executable m_cli
   CompiledObject:     best

--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ depends: [
   "uri"
   "re"
   "rpc"
+  "mtime"
   "cmdliner"
   "ssl"
   "oasis"

--- a/switch/clock.ml
+++ b/switch/clock.ml
@@ -14,7 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(* Work around the lack of clock_gettime on OS X *)
-let time () = Int64.of_float (Unix.gettimeofday () *. 1e9)
+let use_mtime () = Mtime.(to_ns_uint64 (elapsed ()))
 
-let start_time = time ()
+let use_timeofday () = Int64.of_float (Unix.gettimeofday () *. 1e9)
+
+let time =
+  if Mtime.available
+  then use_mtime
+  else begin
+    Logging.warn "No monotonic clock source: falling back to calendar time";
+    use_timeofday
+  end
+

--- a/switch/clock.mli
+++ b/switch/clock.mli
@@ -15,7 +15,4 @@
  *)
 
 val time: unit -> int64
-(** [time ()] sample a monotonic clock in ns *)
-
-val start_time: int64
-(** the time at which the program started *)
+(** [time ()] time in ns since the program started *)

--- a/switch/switch.ml
+++ b/switch/switch.ml
@@ -98,7 +98,7 @@ let snapshot () =
   let all_queues = queues (List.map (fun n -> n, (Q.Directory.find n)) (Q.Directory.list "")) in
   let transient_queues, permanent_queues = List.partition is_transient all_queues in
   let current_time = time () in
-  { start_time; current_time; permanent_queues; transient_queues }
+  { start_time = 0L; current_time; permanent_queues; transient_queues }
 
 open Protocol
 let process_request conn_id session request = match session, request with


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@citrix.com>