### PR TITLE
Make compatible with cohttp.0.19.1

### DIFF
--- a/async/protocol_async.ml
+++ b/async/protocol_async.ml
@@ -33,6 +33,7 @@ module M = struct
     include Cohttp_async_io
 
     let map f t = Deferred.map ~f t
+    let iter f t = Deferred.List.iter t ~f
     let any = Deferred.any
     let is_determined = Deferred.is_determined
   end

--- a/core/s.mli
+++ b/core/s.mli
@@ -27,6 +27,8 @@ module type BACKEND = sig
 
     val map: ('a -> 'b) -> 'a t -> 'b t
 
+    val iter: ('a -> unit t) -> 'a list -> unit t
+
     val any: 'a t list -> 'a t
 
     val is_determined: 'a t -> bool

--- a/lwt/protocol_lwt.ml
+++ b/lwt/protocol_lwt.ml
@@ -29,6 +29,7 @@ module M = struct
     include Cohttp_lwt_unix_io
 
     let map = Lwt.map
+    let iter = Lwt_list.iter_s
     let any = Lwt.choose
     let is_determined t = Lwt.state t <> Lwt.Sleep
   end


### PR DESCRIPTION
We include Cohttp.S.IO and extend it a little; now we need to extend
it a little more since `iter` is not exposed.

Signed-off-by: David Scott dave.scott@citrix.com
